### PR TITLE
Fix service hub link

### DIFF
--- a/components/sections/Services.tsx
+++ b/components/sections/Services.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 
 export function Services() {
   const handleServiceHubClick = () => {
-    window.open("https://carrer.service-hub.jp/", "_blank");
+    window.open("https://service-hub.jp/", "_blank");
   };
 
   return (
@@ -27,7 +27,7 @@ export function Services() {
           <CardContent>
             <div className="mb-6 relative w-full md:w-4/5 lg:w-3/4 mx-auto aspect-video">
               <Image
-                src="https://carrer.service-hub.jp/carrer-hub.png"
+                src="https://service-hub.jp/carrer-hub.png"
                 alt="Carrer Hub サービス画像"
                 fill
                 className="object-cover rounded-md"


### PR DESCRIPTION
## Summary
- update Service Hub URL in Services component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f80bde908321be1226c11f8664f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the service hub website link and image to use the correct URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->